### PR TITLE
Bugfix Promo

### DIFF
--- a/app/models/spree/gateway/paypal_payment.rb
+++ b/app/models/spree/gateway/paypal_payment.rb
@@ -8,6 +8,20 @@ module Spree
     end
 
     def payment_payload(order, web_profile_id, return_url, cancel_url)
+      
+      #paypal don't like it if the subtotal don't add up
+      #If we have Promo we have to change sub_total
+      #TODO: Update for TaxRate, Shipment 
+      sub_total = 0
+      order.all_adjustments.eligible.each do |adj|
+          if (adj.source_type.eql?('Spree::PromotionAction'))
+           sub_total = sub_total + adj.amount
+          end
+      end
+      sub_total = sub_total + order.item_total
+      
+      
+      
       payload = {
         intent: 'sale',
         experience_profile_id: web_profile_id,

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,16 @@
+---
+en:
+  spree:
+    payment_has_been_cancelled: "Die Zahlung wurde Storniert."
+    complete_checkout: "Bitte beenden Sie Paypal Express Checkout bevor Sie weitermachen"
+    paypal_express_checkout: Paypal Express Checkout
+    paypal_transaction: Transaktion
+    paypal_state: Zahlungsstatus
+    paypal_token: Token
+    paypal_payer_id: Zahler ID
+    paypal_payment_id: Transaktions ID
+    paypal_refund_id: "Rückerstattungs ID"
+    paypal_refund_type: "Rückerstattungstyp"
+    paypal_refunded_at: "Rückerstattung zu"
+    paypal_information: "PayPal ist eine einfache und sichere Zahlungsmethode, die es Ihnen erlaubt auf Webseiten und in Apps aus der ganzen Welt zu bezahlen, ohne ihre Kreditkartendetails zu teilen."
+     


### PR DESCRIPTION
I had a little trouble with paypal and Promos. It seems that paypal controls if the items add up to the subtotal and reject the payment if it doesn't add up. I only corrected it for Promos, because I don't use Taxes and Shipment doesn't show up. 